### PR TITLE
課題3-2 分割DLの実装 沓澤遼

### DIFF
--- a/kadai3-2/bookun/client/client.go
+++ b/kadai3-2/bookun/client/client.go
@@ -1,0 +1,160 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Client - 分割DL用クライアント
+type Client struct {
+	URL                        *url.URL
+	HTTPClient                 *http.Client
+	ContentLength, SplitNumber int
+	Filename                   string
+}
+
+// NewClient - Client の初期化
+func NewClient(urlString string) (*Client, error) {
+	var err error
+	client := &Client{}
+	client.URL, err = url.Parse(urlString)
+	splitedPath := strings.Split(client.URL.Path, "/")
+	client.Filename = splitedPath[len(splitedPath)-1]
+	if err != nil {
+		return nil, err
+	}
+	client.HTTPClient = &http.Client{}
+	if err = client.setContentLengthAndSplitNumber(); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// setContentLengthAndSplitNumber - レスポンスヘッダに Accept-Ranges が含まれている場合は分割, ない場合は分割しない
+func (c *Client) setContentLengthAndSplitNumber() error {
+	req, err := http.NewRequest("HEAD", c.URL.String(), nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	c.ContentLength, err = strconv.Atoi(res.Header["Content-Length"][0])
+	if err != nil {
+		return err
+	}
+	if strings.Contains("bytes", res.Header["Accept-Ranges"][0]) {
+		c.SplitNumber = runtime.NumCPU()
+	} else {
+		c.SplitNumber = 1
+	}
+	return nil
+}
+
+func (c *Client) newRequest(ctx context.Context, index int) (*http.Request, error) {
+	req, err := http.NewRequest("GET", c.URL.String(), nil)
+	if err != nil {
+		return req, nil
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Add("User-Agent", "bget")
+	var chank int
+	chank = c.ContentLength / c.SplitNumber
+	low := chank * index
+	high := chank*(index+1) - 1
+	if index+1 == c.SplitNumber && high+1 != c.ContentLength {
+		high = c.ContentLength - 1
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", low, high))
+	return req, nil
+}
+
+func (c *Client) save(ctx context.Context, index int) error {
+	req, err := c.newRequest(ctx, index)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(c.Filename + "_" + strconv.Itoa(index))
+	if err != nil {
+		return err
+	}
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(file, res.Body)
+	if err != nil {
+		return err
+	}
+	file.Close()
+	return nil
+}
+
+func (c *Client) merge(ctx context.Context) error {
+	file, err := os.Create(c.Filename)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < c.SplitNumber; i++ {
+		subFileName := c.Filename + "_" + strconv.Itoa(i)
+		subFile, err := os.Open(subFileName)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(file, subFile)
+		subFile.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Download - 分割DLを実行
+func (c *Client) Download(ctx context.Context) error {
+	eg := errgroup.Group{}
+	for i := 0; i < c.SplitNumber; i++ {
+		index := i
+		eg.Go(func() error {
+			return c.save(ctx, index)
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		c.DeleteFiles()
+		return err
+	}
+	err := c.merge(ctx)
+	c.DeleteFiles()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteFiles - キャンセルなどがあった際に呼ばれる. 分割ファイルの削除を実行.
+func (c *Client) DeleteFiles() error {
+	for i := 0; i < c.SplitNumber; i++ {
+		subFileName := c.Filename + "_" + strconv.Itoa(i)
+		if fi, _ := os.Stat(subFileName); fi != nil {
+			if err := os.Remove(subFileName); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/kadai3-2/bookun/main.go
+++ b/kadai3-2/bookun/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"github.com/gopherdojo/dojo2/kadai3-2/bookun/client"
+)
+
+const (
+	// ExitCodeOK - 正常終了
+	ExitCodeOK = iota
+	// ExitCodeParseFlagError - フラグエラー
+	ExitCodeParseFlagError
+	// ExitCodeCreateHTTPClient - HTTPClient作成失敗
+	ExitCodeCreateHTTPClient
+	// ExitCodeErrorDownload - DL中のエラー
+	ExitCodeErrorDownload
+	// ExitCodeErrorCansel - キャンセルによる終了
+	ExitCodeErrorCansel
+)
+
+// CLI - outStream, errStreamを持つ
+type CLI struct {
+	outStream, errStream io.Writer
+}
+
+// Run - 分割DLを開始. キャンセルを受け付ける
+func (c *CLI) Run(args []string) int {
+	flags := flag.NewFlagSet("bget", flag.ContinueOnError)
+	if err := flags.Parse(args[1:]); err != nil {
+		return ExitCodeParseFlagError
+	}
+	url := args[1]
+	client, err := client.NewClient(url)
+	if err != nil {
+		return ExitCodeCreateHTTPClient
+	}
+	bc := context.Background()
+	ctx, cancel := context.WithCancel(bc)
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	defer func() {
+		signal.Stop(ch)
+		cancel()
+	}()
+	fmt.Fprintln(c.outStream, "Start downloading")
+	go func() error {
+		select {
+		case <-ch:
+			cancel()
+			return nil
+		case <-ctx.Done():
+			if err = client.DeleteFiles(); err != nil {
+				return err
+			}
+			return nil
+		}
+	}()
+	err = client.Download(ctx)
+	if err != nil {
+		return ExitCodeErrorDownload
+	}
+	fmt.Fprintln(c.outStream, "Finish downloading")
+	return ExitCodeOK
+}
+
+func main() {
+	cli := &CLI{os.Stdout, os.Stderr}
+	os.Exit(cli.Run(os.Args))
+}


### PR DESCRIPTION
## 分割ダウンロードを行う

- [x] Rangeアクセスを用いる
ヘッダに Accept-Ranges があるものは `runtime.NumCPU()` の数だけ分割してDLした


- [x] いくつかのゴルーチンでダウンロードしてマージする
複数個の分割DL用goroutineの終了を待った後、マージした

- [x] エラー処理を工夫する
errgroupを利用した

- [x] キャンセルが発生した場合の実装を行う
Ctl-C などのキャンセルが合った場合に途中経過で作成されたファイルの削除を行ってからプログラムが終了するようにした。

## 動作例

```
$ go run main.go <DL対象のURL>
```

## 動作結果例

```
ryo ...kadai3-2/bookun kadai3-2-bookun* $ /usr/bin/time wget https://dl.minio.io/server/minio/release/darwin-amd64/minio
--2018-07-05 17:50:41--  https://dl.minio.io/server/minio/release/darwin-amd64/minio
dl.minio.io (dl.minio.io) をDNSに問いあわせています... 162.243.132.171
dl.minio.io (dl.minio.io)|162.243.132.171|:443 に接続しています... 接続しました。
HTTP による接続要求を送信しました、応答を待っています... 200 OK
長さ: 31227632 (30M) [application/octet-stream]
`minio' に保存中

minio                             100%[==========================================================>]  29.78M  1.40MB/s 時間 41s

2018-07-05 17:51:22 (747 KB/s) - `minio' へ保存完了 [31227632/31227632]

       41.50 real         0.13 user         0.26 sys
ryo ...kadai3-2/bookun kadai3-2-bookun* $ mv minio wget.minio
ryo ...kadai3-2/bookun kadai3-2-bookun $ /usr/bin/time go run main.go https://dl.minio.io/server/minio/release/darwin-amd64/minio
Start downloading
Finish downloading
       14.21 real         0.75 user         0.83 sys
```

## 分割DLしたファイルを実行してみた

```
ryo ...kadai3-2/bookun kadai3-2-bookun* $ ./minio
NAME:
  minio - Cloud Storage Server.

DESCRIPTION:
  Minio is an Amazon S3 compatible object storage server. Use it to store photos, videos, VMs, containers, log files, or any blob of
data as objects.

USAGE:
  minio [FLAGS] COMMAND [ARGS...]

COMMANDS:
  server   Start object storage server.
  gateway  Start object storage gateway.
  update   Check for a new software update.
  version  Print version.

FLAGS:
  --config-dir value, -C value  Path to configuration directory. (default: "/Users/ryo/.minio")
  --quiet                       Disable startup information.
  --json                        Output server logs and startup information in json format.
  --help, -h                    Show help.

VERSION:
  2018-06-29T02:11:29Z
```

正常に実行されていることを確認

## 備考
testまでかけませんでした...